### PR TITLE
Frogpond Added to Whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 settings_local.py
 *.egg-info
 output.nml
+*.idea

--- a/chirp/library/data/artist-whitelist
+++ b/chirp/library/data/artist-whitelist
@@ -3410,6 +3410,7 @@ Fringe Class
 Fripp & Eno
 Frisbie
 Frog Eyes
+Frogpond
 The Frogs
 From Monument To Masses
 Front Line Assembly

--- a/chirp/library/data/artist-whitelist
+++ b/chirp/library/data/artist-whitelist
@@ -95,6 +95,7 @@ Abe Vigoda
 Abel Zénon
 Abelardo Carbono
 Abelardo Carbonó y su Conjunto
+Aberfeldy
 Abibus Oluwa
 The Abigails
 Abilene
@@ -1863,6 +1864,7 @@ The Coctails
 Cocteau Twins
 Codeine
 Cody ChesnuTT
+Coed Pageant
 Coeur Magique
 Coffins
 Coheed and Cambria


### PR DESCRIPTION
In August, it was Goner.  Now it's Frogpond.  Slowly but surely...