### PR TITLE
Use OAuth 2.0 instead of Client Login

### DIFF
--- a/chirp/common/chirpradio.py
+++ b/chirp/common/chirpradio.py
@@ -3,6 +3,7 @@
 import getpass
 import os
 import sys
+import json
 
 from chirp.common import conf
 
@@ -11,33 +12,24 @@ from chirp.common import conf
 _appengine_sdk_path = conf.GOOGLE_APPENGINE_SDK_PATH
 if _appengine_sdk_path not in sys.path:
     sys.path.append(_appengine_sdk_path)
-    sys.path.append(os.path.join(_appengine_sdk_path, "lib/yaml/lib"))
-    sys.path.append(os.path.join(_appengine_sdk_path, "lib/fancy_urllib"))
+    import dev_appserver
+    dev_appserver.fix_sys_path()    # otherwise fancy_urllib will not be found
 
 from google.appengine.ext.remote_api import remote_api_stub
 
 # Add the chirpradio tree to sys.path.
 if conf.CHIRPRADIO_PATH not in sys.path:
     sys.path.append(conf.CHIRPRADIO_PATH)
-    sys.path.append(os.path.join(conf.CHIRPRADIO_PATH, "django.zip"))
+
 
 # This is a very light-weight chirpradio file that we import immediately
 # to check that everything is OK.
 from auth import roles
 
 
-def _auth_func():
-    if conf.CHIRPRADIO_AUTH:
-        fields = conf.CHIRPRADIO_AUTH.strip().split()
-        if len(fields) == 2:
-            return fields
-        sys.stderr.write("Malformed authorization read from %s\n"
-                         % _chirpradio_auth)
-    return raw_input("Username:"), getpass.getpass("Password:")
-
-
-def connect(host=None):
-    if host is None:
-        host = conf.CHIRPRADIO_HOST
-    remote_api_stub.ConfigureRemoteDatastore(
-        "s~chirpradio-hrd", "/_ah/remote_api", _auth_func, host)
+def connect():
+    os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = conf.GOOGLE_APPLICATION_CREDENTIALS
+    project_id = json.load(open(conf.GOOGLE_APPLICATION_CREDENTIALS))['project_id']
+    # You will get UnicodeDecodeError if servername is a unicode string.
+    servername = str('%s.appspot.com' % project_id)
+    remote_api_stub.ConfigureRemoteApiForOAuth(servername, '/_ah/remote_api')

--- a/chirp/common/chirpradio.py
+++ b/chirp/common/chirpradio.py
@@ -29,7 +29,10 @@ from auth import roles
 
 def connect():
     os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = conf.GOOGLE_APPLICATION_CREDENTIALS
-    project_id = json.load(open(conf.GOOGLE_APPLICATION_CREDENTIALS))['project_id']
+
+    with open(conf.GOOGLE_APPLICATION_CREDENTIALS) as fp:
+        project_id = json.load(fp)['project_id']
+
     # You will get UnicodeDecodeError if servername is a unicode string.
     servername = str('%s.appspot.com' % project_id)
     remote_api_stub.ConfigureRemoteApiForOAuth(servername, '/_ah/remote_api')

--- a/settings.py
+++ b/settings.py
@@ -1,20 +1,20 @@
-import os
+import os.path as op
 
 
 # For importing files:
 SAMBA = "/samba"
-LIBRARY_PREFIX = os.path.join(SAMBA, "traktor/Library")
-LIBRARY_DB = os.path.join(LIBRARY_PREFIX, "catalog.sqlite3_db")
-LIBRARY_TMP_PREFIX = os.path.join(LIBRARY_PREFIX, "tmp")
-MUSIC_DROPBOX = os.path.join(SAMBA,
+LIBRARY_PREFIX = op.join(SAMBA, "traktor/Library")
+LIBRARY_DB = op.join(LIBRARY_PREFIX, "catalog.sqlite3_db")
+LIBRARY_TMP_PREFIX = op.join(LIBRARY_PREFIX, "tmp")
+MUSIC_DROPBOX = op.join(SAMBA,
                  "public/public/Departments/Music Dept/New Music Dropbox/")
 # When an album needs fixing, it gets moved here:
-MUSIC_DROPBOX_FIX = os.path.join(SAMBA, "public/Departments/Music Dept/Needs-Fixing")
+MUSIC_DROPBOX_FIX = op.join(SAMBA, "public/Departments/Music Dept/Needs-Fixing")
 
 
 # Path to checkout of App Engine code, from
 # http://code.google.com/p/chirpradio/
-CHIRPRADIO_PATH = os.path.expanduser('~/chirpradio')
+CHIRPRADIO_PATH = op.expanduser('~/chirpradio')
 # You can set this to a string of 'username password' for logging into
 # App Engine.  When None, the username/pass will be prompted on the
 # command line.
@@ -49,3 +49,7 @@ BARIX_PORT = 80
 
 # For auto-mounting:
 MOUNT_BY_HDSN_ROOT = "/mnt/by_hdsn/"
+
+# You can create a new service account key on the API manager credentials page:
+# https://console.cloud.google.com/apis/credentials
+GOOGLE_APPLICATION_CREDENTIALS = op.expanduser('~/.ssh/chirpradio_service_account_key.json')

--- a/settings.py
+++ b/settings.py
@@ -15,10 +15,6 @@ MUSIC_DROPBOX_FIX = op.join(SAMBA, "public/Departments/Music Dept/Needs-Fixing")
 # Path to checkout of App Engine code, from
 # http://code.google.com/p/chirpradio/
 CHIRPRADIO_PATH = op.expanduser('~/chirpradio')
-# You can set this to a string of 'username password' for logging into
-# App Engine.  When None, the username/pass will be prompted on the
-# command line.
-CHIRPRADIO_AUTH = None
 CHIRPRADIO_HOST = 'chirpradio.appspot.com'
 GOOGLE_APPENGINE_SDK_PATH = '/usr/local/google_appengine'
 
@@ -52,4 +48,6 @@ MOUNT_BY_HDSN_ROOT = "/mnt/by_hdsn/"
 
 # You can create a new service account key on the API manager credentials page:
 # https://console.cloud.google.com/apis/credentials
-GOOGLE_APPLICATION_CREDENTIALS = op.expanduser('~/.ssh/chirpradio_service_account_key.json')
+# This service key is needed when using the Remote API:
+# https://cloud.google.com/appengine/docs/python/tools/remoteapi
+GOOGLE_APPLICATION_CREDENTIALS = op.expanduser('~/.chirpradio_service_account_key.json')


### PR DESCRIPTION
This change will allow the various scripts to use OAuth 2.0 to connect to the Remote API instead of the now-defunct Client Login. See the [relevant docs](https://cloud.google.com/appengine/docs/python/tools/remoteapi#using_the_remote_api_in_a_local_client).