### PR TITLE
Refactoring of command functions to make them runnable by the new web interface

### DIFF
--- a/chirp/common/printing.py
+++ b/chirp/common/printing.py
@@ -22,6 +22,8 @@ class CustomPrint(object):
             if len(kwargs) == 0:
                 print
         else:
+            if not isinstance(message, basestring):
+                message = unicode(message)
             # Encode in utf-8 so that the message can be displayed in the console.
             print(message.encode('utf-8'))
 

--- a/chirp/common/printing.py
+++ b/chirp/common/printing.py
@@ -1,0 +1,30 @@
+import contextlib
+
+
+class CustomPrint(object):
+    """
+    This class defines a callable object that works similarly to the print()
+    function. However, it provides a context manager that allows you to specify
+    a different write function that can be used to send messages to somewhere
+    other than standard output (for example, a web interface).
+
+    """
+
+    def __init__(self):
+        self.write = self.default_write
+
+    def __call__(self, message, **kwargs):
+        self.write(message, **kwargs)
+
+    def default_write(self, message, **kwargs):
+        if message:
+            print(message)
+
+    @contextlib.contextmanager
+    def use_write_function(self, func):
+        self.write = func
+        yield
+        self.write = self.default_write
+
+
+cprint = CustomPrint()

--- a/chirp/common/printing.py
+++ b/chirp/common/printing.py
@@ -19,6 +19,8 @@ class CustomPrint(object):
     def default_write(self, message, **kwargs):
         if message:
             print(message)
+        else:
+            print
 
     @contextlib.contextmanager
     def use_write_function(self, func):

--- a/chirp/common/printing.py
+++ b/chirp/common/printing.py
@@ -17,8 +17,13 @@ class CustomPrint(object):
         self.write(message, **kwargs)
 
     def default_write(self, message=None, **kwargs):
-        if message:
-            print(message)
+        if message is None:
+            # If there were no arguments at all, print a newline to stdout.
+            if len(kwargs) == 0:
+                print
+        else:
+            # Encode in utf-8 so that the message can be displayed in the console.
+            print(message.encode('utf-8'))
 
     @contextlib.contextmanager
     def use_write_function(self, func):

--- a/chirp/common/printing.py
+++ b/chirp/common/printing.py
@@ -13,14 +13,12 @@ class CustomPrint(object):
     def __init__(self):
         self.write = self.default_write
 
-    def __call__(self, message, **kwargs):
+    def __call__(self, message=None, **kwargs):
         self.write(message, **kwargs)
 
-    def default_write(self, message, **kwargs):
+    def default_write(self, message=None, **kwargs):
         if message:
             print(message)
-        else:
-            print
 
     @contextlib.contextmanager
     def use_write_function(self, func):

--- a/chirp/library/do_dump_new_artists_in_dropbox.py
+++ b/chirp/library/do_dump_new_artists_in_dropbox.py
@@ -38,9 +38,9 @@ def main_generator():
         yield
 
     if rewrite:
-        cprint('Artist whitelist updated')
+        cprint('Artist whitelist updated', type='highlight')
     else:
-        cprint('Found %d new artists' % len(to_print))
+        cprint('Found %d new artists' % len(to_print), type='success')
 
 
 def main():

--- a/chirp/library/do_dump_new_artists_in_dropbox.py
+++ b/chirp/library/do_dump_new_artists_in_dropbox.py
@@ -2,6 +2,7 @@
 
 import codecs
 import sys
+from chirp.common.printing import cprint
 from chirp.library import artists
 from chirp.library import dropbox
 
@@ -15,7 +16,7 @@ def main():
         try:
             tpe1 = au_file.mutagen_id3["TPE1"].text[0]
         except:
-            print '** file: %r' % au_file.path
+            cprint('** file: %r' % au_file.path)
             raise
         if artists.standardize(tpe1) is None:
             new_artists.add(tpe1)
@@ -24,7 +25,7 @@ def main():
     if rewrite:
         to_print.extend(artists.all())
     to_print.sort(key=artists.sort_key)
-    
+
     output = None
     if rewrite:
         output = codecs.open(artists._WHITELIST_FILE, "w", "utf-8")
@@ -33,10 +34,15 @@ def main():
             output.write(tpe1)
             output.write("\n")
         else:
-            print tpe1.encode("utf-8")
+            cprint(tpe1.encode("utf-8"))
+        yield
+
     if rewrite:
-        print "Artist whitelist updated"
+        cprint('Artist whitelist updated', type='success')
+    else:
+        cprint('Found %d new artists' % len(to_print), type='success')
 
 
 if __name__ == "__main__":
-    main()
+    for _ in main():
+        pass

--- a/chirp/library/do_dump_new_artists_in_dropbox.py
+++ b/chirp/library/do_dump_new_artists_in_dropbox.py
@@ -7,7 +7,7 @@ from chirp.library import artists
 from chirp.library import dropbox
 
 
-def main():
+def main_generator():
     rewrite = ("--rewrite" in sys.argv)
 
     drop = dropbox.Dropbox()
@@ -38,11 +38,15 @@ def main():
         yield
 
     if rewrite:
-        cprint('Artist whitelist updated', type='success')
+        cprint('Artist whitelist updated')
     else:
-        cprint('Found %d new artists' % len(to_print), type='success')
+        cprint('Found %d new artists' % len(to_print))
+
+
+def main():
+    for _ in main_generator():
+        pass
 
 
 if __name__ == "__main__":
-    for _ in main():
-        pass
+    main()

--- a/chirp/library/do_dump_new_artists_in_dropbox.py
+++ b/chirp/library/do_dump_new_artists_in_dropbox.py
@@ -7,9 +7,7 @@ from chirp.library import artists
 from chirp.library import dropbox
 
 
-def main_generator():
-    rewrite = ("--rewrite" in sys.argv)
-
+def main_generator(rewrite):
     drop = dropbox.Dropbox()
     new_artists = set()
     for au_file in drop.tracks():
@@ -44,7 +42,7 @@ def main_generator():
 
 
 def main():
-    for _ in main_generator():
+    for _ in main_generator("--rewrite" in sys.argv):
         pass
 
 

--- a/chirp/library/do_dump_new_artists_in_dropbox.py
+++ b/chirp/library/do_dump_new_artists_in_dropbox.py
@@ -42,7 +42,7 @@ def main_generator(rewrite):
 
 
 def main():
-    for _ in main_generator("--rewrite" in sys.argv):
+    for _ in main_generator(rewrite="--rewrite" in sys.argv):
         pass
 
 

--- a/chirp/library/do_generate_collection_nml.py
+++ b/chirp/library/do_generate_collection_nml.py
@@ -5,12 +5,18 @@
 import codecs
 import sys
 import time
+from chirp.common.printing import cprint
 from chirp.common import conf
 from chirp.library import database
 from chirp.library import nml_writer
 
 
 def main():
+    for _ in main_generator():
+        pass
+
+
+def main_generator():
     out_fh = codecs.open("output.nml", "w", "utf-8")
     # TODO(trow): Don't hard-wire the drive letter.
     writer = nml_writer.NMLWriter("T:", "/Library", out_fh)
@@ -20,12 +26,14 @@ def main():
     for au_file in db.get_all():
         writer.write(au_file)
         count += 1
+        elapsed_t = time.time() - start_t
+        cprint(type='count', count=count, elapsed_seconds=elapsed_t)        
         if count % 1000 == 0:
-            elapsed_t = time.time() - start_t
             sys.stderr.write("%d (%.1f/s)...\n" % (count, count / elapsed_t))
+        yield
     writer.close()
     out_fh.close()
-    sys.stderr.write("Wrote %d tracks to collection\n" % count)
+    cprint("Wrote %d tracks to collection\n" % count, type='success')
 
 
 if __name__ == "__main__":

--- a/chirp/library/do_generate_collection_nml.py
+++ b/chirp/library/do_generate_collection_nml.py
@@ -27,9 +27,9 @@ def main_generator():
         writer.write(au_file)
         count += 1
         elapsed_t = time.time() - start_t
-        cprint(type='count', count=count, elapsed_seconds=elapsed_t)        
+        cprint(type='count', count=count, elapsed_seconds=elapsed_t)
         if count % 1000 == 0:
-            sys.stderr.write("%d (%.1f/s)...\n" % (count, count / elapsed_t))
+            sys.stderr.write("{count} ({rate:.1f}/s)...\n".format(count=count, rate=count / elapsed_t))
         yield
     writer.close()
     out_fh.close()

--- a/chirp/library/do_periodic_import.py
+++ b/chirp/library/do_periodic_import.py
@@ -35,8 +35,7 @@ def import_albums(inbox):
         for alb in inbox.albums():
             alb.drop_payloads()
             album_count += 1
-            print "#%d" % album_count,
-            print (u'"%s"' % alb.title()).encode("utf-8"),
+            print u'#%d "%s"' % (album_count, alb.title().encode("utf-8"))
             if alb.tags():
                 print "(%s)" % ", ".join(alb.tags())
             else:
@@ -45,8 +44,8 @@ def import_albums(inbox):
             if alb.is_compilation():
                 print "Compilation"
                 for i, au in enumerate(alb.all_au_files):
-                    print "  %02d:" % (i+1,),
-                    print unicode(au.mutagen_id3["TPE1"]).encode("utf-8")
+                    artist = unicode(au.mutagen_id3["TPE1"]).encode("utf-8")
+                    print "  %02d: %s" % (i+1, artist)
             else:
                 print alb.artist_name().encode("utf-8")
             print "%d tracks / %d minutes" % (
@@ -84,7 +83,7 @@ def import_albums(inbox):
                 print "***** IMPORT ERROR"
                 print "*****   %s\n" % str(ex)
                 error_count += 1
-            
+
             sys.stdout.flush()
     except analyzer.InvalidFileError, ex:
         print "***** INVALID FILE ERROR"

--- a/chirp/library/do_periodic_import.py
+++ b/chirp/library/do_periodic_import.py
@@ -21,10 +21,8 @@ VOLUME_NUMBER = 1
 IMPORT_SIZE_LIMIT = 0.95 * (3 << 30)  # 95% of 3GB.
 
 
-dry_run = ("--actually-do-import" not in sys.argv)
-
-
-def import_albums(inbox):
+def import_albums(dry_run):
+    inbox = dropbox.Dropbox()
     prescan_timestamp = timestamp.now()
     error_count = 0
     album_count = 0
@@ -123,6 +121,7 @@ def import_albums(inbox):
 
 
 def main():
+    dry_run = "--actually-do-import" not in sys.argv
     print
     if dry_run:
         cprint("+++ This is only a dry run.  No actual import will occur.")
@@ -135,8 +134,7 @@ def main():
         cprint("***")
         cprint("*" * 70)
     print
-    inbox = dropbox.Dropbox()
-    for _ in import_albums(inbox):
+    for _ in import_albums(dry_run):
         pass
 
 

--- a/chirp/library/do_periodic_import.py
+++ b/chirp/library/do_periodic_import.py
@@ -56,14 +56,14 @@ def import_albums(dry_run):
             collision = False
             for au in alb.all_au_files:
                 if au.fingerprint in seen_fp:
-                    cprint("***** ERROR: DUPLICATE TRACK WITHIN IMPORT")
+                    cprint("***** ERROR: DUPLICATE TRACK WITHIN IMPORT", type='error')
                     cprint("This one is at %s" % au.path)
                     cprint("Other one is at %s" % seen_fp[au.fingerprint].path)
                     collision = True
                     break
                 fp_au_file = db.get_by_fingerprint(au.fingerprint)
                 if fp_au_file is not None:
-                    cprint("***** ERROR: TRACK ALREADY IN LIBRARY")
+                    cprint("***** ERROR: TRACK ALREADY IN LIBRARY", type='error')
                     cprint(unicode(fp_au_file.mutagen_id3))
                     collision = True
                     break
@@ -93,7 +93,7 @@ def import_albums(dry_run):
     cprint("-" * 40)
     cprint("Found %d albums" % album_count)
     if error_count > 0:
-        cprint("Saw %d errors" % error_count)
+        cprint("Saw %d errors" % error_count, type='failure')
         return
     cprint("No errors found")
 

--- a/chirp/library/do_periodic_import.py
+++ b/chirp/library/do_periodic_import.py
@@ -34,7 +34,7 @@ def import_albums(dry_run):
         for alb in inbox.albums():
             alb.drop_payloads()
             album_count += 1
-            cprint(u'#%d "%s"' % (album_count, alb.title().encode("utf-8")))
+            cprint(u'#{num} "{title}"'.format(num=album_count, title=alb.title()))
             if alb.tags():
                 cprint("(%s)" % ", ".join(alb.tags()))
             else:
@@ -43,11 +43,11 @@ def import_albums(dry_run):
             if alb.is_compilation():
                 cprint("Compilation")
                 for i, au in enumerate(alb.all_au_files):
-                    artist = unicode(au.mutagen_id3["TPE1"]).encode("utf-8")
-                    cprint("  %02d: %s" % (i+1, artist))
+                    artist = unicode(au.mutagen_id3["TPE1"])
+                    cprint("  {:02d}: {}".format(i+1, artist))
             else:
-                cprint(alb.artist_name().encode("utf-8"))
-            cprint("%d tracks / %d minutes" % (
+                cprint(alb.artist_name())
+            cprint("{} tracks / {} minutes".format(
                 len(alb.all_au_files), int(duration_ms / 60000)))
             cprint("ID=%015x" % alb.album_id)
             sys.stdout.flush()
@@ -64,7 +64,7 @@ def import_albums(dry_run):
                 fp_au_file = db.get_by_fingerprint(au.fingerprint)
                 if fp_au_file is not None:
                     cprint("***** ERROR: TRACK ALREADY IN LIBRARY")
-                    cprint(unicode(fp_au_file.mutagen_id3).encode("utf-8"))
+                    cprint(unicode(fp_au_file.mutagen_id3))
                     collision = True
                     break
                 seen_fp[au.fingerprint] = au

--- a/chirp/library/do_periodic_import.py
+++ b/chirp/library/do_periodic_import.py
@@ -122,7 +122,7 @@ def import_albums(dry_run):
 
 def main():
     dry_run = "--actually-do-import" not in sys.argv
-    print
+    cprint()
     if dry_run:
         cprint("+++ This is only a dry run.  No actual import will occur.")
         cprint("+++ We will only scan the dropbox looking for errors.")
@@ -133,7 +133,7 @@ def main():
         cprint("*** If no errors are found, the music library will be updated!")
         cprint("***")
         cprint("*" * 70)
-    print
+    cprint()
     for _ in import_albums(dry_run):
         pass
 

--- a/chirp/library/do_periodic_import.py
+++ b/chirp/library/do_periodic_import.py
@@ -98,7 +98,7 @@ def import_albums(dry_run):
     cprint("No errors found")
 
     if dry_run:
-        cprint("Dry run --- terminating")
+        cprint("Dry run --- terminating", type='success')
         return
 
     txn = None
@@ -113,7 +113,7 @@ def import_albums(dry_run):
         if txn.total_size_in_bytes > IMPORT_SIZE_LIMIT:
             txn.commit(LIBRARY_PREFIX)
             txn = None
-        yield # process an album
+        yield # import an album
     # Flush out any remaining tracks.
     if txn:
         txn.commit(LIBRARY_PREFIX)

--- a/chirp/library/do_periodic_import.py
+++ b/chirp/library/do_periodic_import.py
@@ -6,6 +6,7 @@ import sys
 from chirp.common import timestamp
 from chirp.common.conf import (LIBRARY_PREFIX, LIBRARY_DB,
                                    LIBRARY_TMP_PREFIX)
+from chirp.common.printing import cprint
 from chirp.library import album
 from chirp.library import analyzer
 from chirp.library import artists
@@ -35,37 +36,37 @@ def import_albums(inbox):
         for alb in inbox.albums():
             alb.drop_payloads()
             album_count += 1
-            print u'#%d "%s"' % (album_count, alb.title().encode("utf-8"))
+            cprint(u'#%d "%s"' % (album_count, alb.title().encode("utf-8")))
             if alb.tags():
-                print "(%s)" % ", ".join(alb.tags())
+                cprint("(%s)" % ", ".join(alb.tags()))
             else:
                 print
             duration_ms = sum(au.duration_ms for au in alb.all_au_files)
             if alb.is_compilation():
-                print "Compilation"
+                cprint("Compilation")
                 for i, au in enumerate(alb.all_au_files):
                     artist = unicode(au.mutagen_id3["TPE1"]).encode("utf-8")
-                    print "  %02d: %s" % (i+1, artist)
+                    cprint("  %02d: %s" % (i+1, artist))
             else:
-                print alb.artist_name().encode("utf-8")
-            print "%d tracks / %d minutes" % (
-                len(alb.all_au_files), int(duration_ms / 60000))
-            print "ID=%015x" % alb.album_id
+                cprint(alb.artist_name().encode("utf-8"))
+            cprint("%d tracks / %d minutes" % (
+                len(alb.all_au_files), int(duration_ms / 60000)))
+            cprint("ID=%015x" % alb.album_id)
             sys.stdout.flush()
 
             # Check that the album isn't already in library.
             collision = False
             for au in alb.all_au_files:
                 if au.fingerprint in seen_fp:
-                    print "***** ERROR: DUPLICATE TRACK WITHIN IMPORT"
-                    print "This one is at %s" % au.path
-                    print "Other one is at %s" % seen_fp[au.fingerprint].path
+                    cprint("***** ERROR: DUPLICATE TRACK WITHIN IMPORT")
+                    cprint("This one is at %s" % au.path)
+                    cprint("Other one is at %s" % seen_fp[au.fingerprint].path)
                     collision = True
                     break
                 fp_au_file = db.get_by_fingerprint(au.fingerprint)
                 if fp_au_file is not None:
-                    print "***** ERROR: TRACK ALREADY IN LIBRARY"
-                    print unicode(fp_au_file.mutagen_id3).encode("utf-8")
+                    cprint("***** ERROR: TRACK ALREADY IN LIBRARY")
+                    cprint(unicode(fp_au_file.mutagen_id3).encode("utf-8"))
                     collision = True
                     break
                 seen_fp[au.fingerprint] = au
@@ -78,28 +79,29 @@ def import_albums(inbox):
             alb.set_volume_and_import_timestamp(0xff, prescan_timestamp)
             try:
                 alb.standardize()
-                print "OK!\n"
+                cprint("OK!\n")
             except (import_file.ImportFileError, album.AlbumError), ex:
-                print "***** IMPORT ERROR"
-                print "*****   %s\n" % str(ex)
+                cprint("***** IMPORT ERROR")
+                cprint("*****   %s\n" % str(ex))
                 error_count += 1
 
             sys.stdout.flush()
-    except analyzer.InvalidFileError, ex:
-        print "***** INVALID FILE ERROR"
-        print "*****   %s\n" % str(ex)
+            yield # scanned an album
+    except analyzer.InvalidFileError as ex:
+        cprint("***** INVALID FILE ERROR", type='error')
+        cprint("*****   %s\n" % str(ex), type='error')
         error_count += 1
 
-    print "-" * 40
-    print "Found %d albums" % album_count
+    cprint("-" * 40)
+    cprint("Found %d albums" % album_count)
     if error_count > 0:
-        print "Saw %d errors" % error_count
-        return False
-    print "No errors found"
+        cprint("Saw %d errors" % error_count)
+        return
+    cprint("No errors found")
 
     if dry_run:
-        print "Dry run --- terminating"
-        return True
+        cprint("Dry run --- terminating")
+        return
 
     txn = None
     for alb in inbox.albums():
@@ -113,27 +115,29 @@ def import_albums(inbox):
         if txn.total_size_in_bytes > IMPORT_SIZE_LIMIT:
             txn.commit(LIBRARY_PREFIX)
             txn = None
+        yield # process an album
     # Flush out any remaining tracks.
     if txn:
         txn.commit(LIBRARY_PREFIX)
-    return True
+    return
 
 
 def main():
     print
     if dry_run:
-        print "+++ This is only a dry run.  No actual import will occur."
-        print "+++ We will only scan the dropbox looking for errors."
+        cprint("+++ This is only a dry run.  No actual import will occur.")
+        cprint("+++ We will only scan the dropbox looking for errors.")
     else:
-        print "*" * 70
-        print "***"
-        print "*** WARNING!  This is a real import!"
-        print "*** If no errors are found, the music library will be updated!"
-        print "***"
-        print "*" * 70
+        cprint("*" * 70)
+        cprint("***")
+        cprint("*** WARNING!  This is a real import!")
+        cprint("*** If no errors are found, the music library will be updated!")
+        cprint("***")
+        cprint("*" * 70)
     print
     inbox = dropbox.Dropbox()
-    import_albums(inbox)
+    for _ in import_albums(inbox):
+        pass
 
 
 if __name__ == "__main__":

--- a/chirp/library/do_push_artists_to_chirpradio.py
+++ b/chirp/library/do_push_artists_to_chirpradio.py
@@ -34,7 +34,7 @@ def main_generator():
             continue
         std_name = artists.standardize(art.name)
         if std_name != art.name:
-            cprint("Mapping %d: %s => %s" % (mapped, art.name, std_name))
+            cprint("Mapping {}: {} => {}".format(mapped, art.name, std_name))
             mapped += 1
             art.name = std_name
             idx = search.Indexer()

--- a/chirp/library/do_push_artists_to_chirpradio.py
+++ b/chirp/library/do_push_artists_to_chirpradio.py
@@ -3,14 +3,21 @@ Pushes artists that have been added to the whitelist up to chirpradio.
 """
 
 import time
+
 from chirp.library import artists
 
+from chirp.common.printing import cprint
 from chirp.common import chirpradio
 from djdb import models
 from djdb import search
 
 
 def main():
+    for _ in main_generator():
+        pass
+
+
+def main_generator():
     chirpradio.connect()
 
     dry_run = False
@@ -27,7 +34,7 @@ def main():
             continue
         std_name = artists.standardize(art.name)
         if std_name != art.name:
-            print "Mapping %d: %s => %s" % (mapped, art.name, std_name)
+            cprint("Mapping %d: %s => %s" % (mapped, art.name, std_name))
             mapped += 1
             art.name = std_name
             idx = search.Indexer()
@@ -36,23 +43,24 @@ def main():
             if not dry_run:
                 idx.save()
         all_chirpradio_artists.add(art.name)
+        yield
 
     to_push = list(all_library_artists.difference(all_chirpradio_artists))
 
-    print "Pushing %d artists" % len(to_push)
+    cprint("Pushing %d artists" % len(to_push))
     while to_push:
         # Push the artists in batches of 50
         this_push = to_push[:50]
         to_push = to_push[50:]
         idx = search.Indexer()
         for name in this_push:
-            print name
+            cprint(name)
             art = models.Artist.create(parent=idx.transaction, name=name)
             idx.add_artist(art)
         if not dry_run:
             idx.save()
-        print "+++++ Indexer saved"
-
+        cprint("+++++ Indexer saved")
+        yield
 
 
 if __name__ == "__main__":

--- a/chirp/library/import_transaction.py
+++ b/chirp/library/import_transaction.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+from chirp.common.printing import cprint
 from chirp.library import album
 from chirp.library import audio_file
 from chirp.library import import_file
@@ -17,10 +18,10 @@ class ImportTransaction(object):
         self._tmp_prefix = tmp_prefix
         self._dry_run = dry_run
 
-        self.total_size_in_bytes = 0 
+        self.total_size_in_bytes = 0
         self.num_albums = 0
         self._all_au_files = []
-    
+
     @property
     def num_tracks(self):
         return len(self._all_au_files)
@@ -31,7 +32,7 @@ class ImportTransaction(object):
             self._volume, self._import_timestamp)
         alb.ensure_payloads()
 
-        print 'Adding Album "%s"' % alb.title().encode("utf-8")
+        cprint('Adding Album "%s"' % alb.title().encode("utf-8"))
         sys.stdout.flush()
 
         # Write the files to our temporary prefix.
@@ -62,10 +63,10 @@ class ImportTransaction(object):
             ufid_prefix = ufid_prefix[:-1]
         tmp_dir = os.path.join(self._tmp_prefix, ufid_prefix)
         real_dir = os.path.join(target_prefix, ufid_prefix)
-        print "*** Committing %d albums / %d bytes" % (
-            self.num_albums, self.total_size_in_bytes)
-        print "*** tmp_dir=%s" % tmp_dir
-        print "*** real_dir=%s" % real_dir
+        cprint("*** Committing %d albums / %d bytes" % (
+            self.num_albums, self.total_size_in_bytes))
+        cprint("*** tmp_dir=%s" % tmp_dir)
+        cprint("*** real_dir=%s" % real_dir)
         sys.stdout.flush()
         os.renames(tmp_dir, real_dir)
         txn.commit()
@@ -75,5 +76,3 @@ class ImportTransaction(object):
             out.write(path)
             out.write("\n")
         out.close()
-
-        


### PR DESCRIPTION
Currently the web interface is here: https://github.com/feihong/command-center

To be runnable by the web interface each function needs to be refactored into a generator function and use calls to cprint() in the place of print statements. The reasons for the refactoring are:

- Being a generator function allows the command to be easily interrupted in the middle of a run.
- Using the cprint() function allows messages to be directed to web sockets instead of standard out.