### PR TITLE
Handle printing messages that have already been encoded

### DIFF
--- a/chirp/common/printing.py
+++ b/chirp/common/printing.py
@@ -24,8 +24,11 @@ class CustomPrint(object):
         else:
             if not isinstance(message, basestring):
                 message = unicode(message)
-            # Encode in utf-8 so that the message can be displayed in the console.
-            print(message.encode('utf-8'))
+            if not isinstance(message, str):
+                # This is a Unicode object so we should encode it as a byte
+                # string before writing it to the console.
+                message = message.encode('utf-8')
+            print(message)
 
     @contextlib.contextmanager
     def use_write_function(self, func):

--- a/chirp/common/printing_test.py
+++ b/chirp/common/printing_test.py
@@ -1,0 +1,15 @@
+import unittest
+
+from chirp.common.printing import cprint
+
+
+class TestCustomPrint(unittest.TestCase):
+
+    def test_print_unicode(self):
+        cprint(u'Ivan Krsti\u0107')
+
+    def test_print_bytes(self):
+        cprint(u'Ivan Krsti\u0107'.encode('utf8'))
+
+    def test_print_numbers(self):
+        cprint(1000)


### PR DESCRIPTION
This fixes the following traceback:
````
Traceback (most recent call last):
  File "/home/musiclib/.virtualenvs/chirpradio-machine/bin/do_dump_new_artists_in_dropbox", line 9, in <module>
    load_entry_point('chirp==2.0', 'console_scripts', 'do_dump_new_artists_in_dropbox')()
  File "/home/musiclib/chirpradio-machine-new/chirp/library/do_dump_new_artists_in_dropbox.py", line 45, in main
    for _ in main_generator(rewrite="--rewrite" in sys.argv):
  File "/home/musiclib/chirpradio-machine-new/chirp/library/do_dump_new_artists_in_dropbox.py", line 35, in main_generator
    cprint(tpe1.encode("utf-8"))
  File "/home/musiclib/chirpradio-machine-new/chirp/common/printing.py", line 17, in __call__
    self.write(message, **kwargs)
  File "/home/musiclib/chirpradio-machine-new/chirp/common/printing.py", line 28, in default_write
    print(message.encode('utf-8'))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 3: ordinal not in range(128)
````