### PR TITLE
Add ability to delete audio file records from sqlite3 database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,14 +230,8 @@ reference to it in the db).
 Usage::
 
   See what will be deleted:
-  ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id>
 
-  Actually delete:
-  ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id> --delete
-
-  Flags:
-   --db = specify a filesystem path to an alternate location for the SQLite database file
-   --delete = actually do the delete. Nothing will be deleted without this flag.
+  do_delete_audio_file_from_db <fingerprint_id> <fingerprint_id>
 
 
 Stream Archiver

--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ steps below. You must provide the fingerprint of the song or songs that you
 wish to remove.
 
 This does not delete the actual audio file from the filesystem or the ChirpRadio
-web app. It just removes the database entires in the SQLite database.
+web app. It just removes the database entries in the SQLite database.
 
 To delete the audio file from the ChirpRadio `web app`_, `log in`_ as an
 administrator, search for a track that was deleted, and click the red X to

--- a/README.rst
+++ b/README.rst
@@ -224,14 +224,19 @@ If you wish to remove a song's metadata from the database, you can follow the
 steps below. You must provide the fingerprint of the song or songs that you
 wish to remove.
 
-This does not delete the actual audio file from the filesystem (just the
-reference to it in the db).
+This does not delete the actual audio file from the filesystem or the ChirpRadio
+web app. It just removes the database entires in the SQLite database.
+
+To delete the audio file from the ChirpRadio web app, log in as an
+administrator, search for a track that was deleted, and click the red X to
+revoke the track.
 
 Usage::
 
   See what will be deleted:
 
   do_delete_audio_file_from_db <fingerprint_id> <fingerprint_id>
+
 
 
 Stream Archiver

--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,35 @@ To upload the album and track information, you must specify a "start timestamp" 
 If you don’t see any output from this command you probably entered the wrong timestamp.  It should show you verbose output of all the new albums uploading to App Engine.
 
 
+Remove Audio File Records
+-------------------------
+
+Remove audio files and their M3U tags based on a fingerprint id given.
+
+After running an import, the SQLite database file (as set by the LIBRARY_DB
+settings variable) will contain metadata about the songs imported. The import
+process will have assigned each song a unique fingerprint.
+
+If you wish to remove a song's metadata from the database, you can follow the
+steps below. You must provide the fingerprint of the song or songs that you
+wish to remove.
+
+This does not delete the actual audio file from the filesystem (just the
+reference to it in the db).
+
+Usage::
+
+  See what will be deleted:
+  ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id>
+
+  Actually delete:
+  ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id> --delete
+
+  Flags:
+   --db = specify a filesystem path to an alternate location for the SQLite database file
+   --delete = actually do the delete. Nothing will be deleted without this flag.
+
+
 Stream Archiver
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -227,11 +227,11 @@ wish to remove.
 This does not delete the actual audio file from the filesystem or the ChirpRadio
 web app. It just removes the database entries in the SQLite database.
 
-To delete the audio file from the ChirpRadio `web app`_, `log in`_ as an
+To delete the audio file from the ChirpRadio web app (`source code`_), `log in`_ as an
 administrator, search for a track that was deleted, and click the red X to
 revoke the track.
 
-.. _`web app`: https://github.com/chirpradio/chirpradio/
+.. _`source code`: https://github.com/chirpradio/chirpradio/
 .. _`log in`: https://chirpradio.appspot.com/djdb/
 
 *Usage:*

--- a/README.rst
+++ b/README.rst
@@ -227,16 +227,22 @@ wish to remove.
 This does not delete the actual audio file from the filesystem or the ChirpRadio
 web app. It just removes the database entires in the SQLite database.
 
-To delete the audio file from the ChirpRadio web app, log in as an
+To delete the audio file from the ChirpRadio `web app`_, `log in`_ as an
 administrator, search for a track that was deleted, and click the red X to
 revoke the track.
 
-Usage::
+.. _`web app`: https://github.com/chirpradio/chirpradio/
+.. _`log in`: https://chirpradio.appspot.com/djdb/
 
-  See what will be deleted:
+*Usage:*
+
+See what will be deleted::
 
   do_delete_audio_file_from_db <fingerprint_id> <fingerprint_id>
 
+If that looks correct, you need to run it once more with --delete to perform the deletion::
+
+  do_delete_audio_file_from_db <fingerprint_id> <fingerprint_id> --delete
 
 
 Stream Archiver

--- a/chirp/library/data/artist-whitelist
+++ b/chirp/library/data/artist-whitelist
@@ -1727,6 +1727,7 @@ Buffalos Bay
 The Bug
 The Bug & Warrior Queen
 The Bug vs Earth
+Bugg
 Bugg Superstar
 The Buggles
 Bugs in the Dark
@@ -2894,6 +2895,7 @@ Daytona
 Daywalker & CF
 Daïtro
 The dB's
+dbh
 De Facto
 De Frank Professionals
 De La Hoya
@@ -4727,6 +4729,7 @@ Goudron
 Government Issue
 Grabass Charlestons
 Grabbit
+Grace Basement
 Grace Jones
 Gracie and Rachel
 Grade
@@ -5040,6 +5043,7 @@ Hedvig Mollestad Trio
 Helado Negro
 Helen
 Helen Kane
+Helen Kelter Skelter
 Helen Money
 Helen Morgan
 Helene Smith
@@ -7363,6 +7367,7 @@ Marianne Faithfull
 Marianne Faithfull with Kate & Anna McGarrigle
 Mariano Rodriguez, Karina Vismara & Jonah Schwartz
 Marie Knight
+Marie/Lepanto
 Mariee Sioux
 Marielle V Jakobsons
 Marijata
@@ -8017,6 +8022,7 @@ Mothers
 Motion City Soundtrack
 Motion Plus
 Motorama
+MOTORCADE
 Motown Artists
 Mott The Hoople
 Motörhead
@@ -9951,6 +9957,7 @@ The Sainte Catherines
 Saintseneca
 Saknatee Srichiangmai
 Saksiam Petchchompu & Pornsurapon Petchseethong
+Salad Boys
 Salami J.R.
 Salem
 Salim Nourallah
@@ -10132,6 +10139,7 @@ Sean Donnelly
 Sean Flinn
 Sean Flinn & The Royal We
 Sean Lennon with Jack Shit
+Sean Morales
 Sean Na-Na
 Sean Nelson
 Sean Rowe
@@ -10225,6 +10233,7 @@ Shai Hulud
 Shakey Graves
 The Shaky Hands
 Shalabi Effect
+Shame
 Shamir
 Shana Falana
 Shane MacGowan with Johnny Depp & Gore Verbinski
@@ -11258,6 +11267,7 @@ Tera Melos
 Terekke
 Teresa Cristina
 Teri Sario
+Terminal Mind
 Terminals
 Terrace Martin
 Terrace Martin Presents The Pollyseeds
@@ -12546,6 +12556,7 @@ Zigtebra
 The Zincs
 Zion I
 Zion I & The Grouch
+Zion Rodman
 ZKPR
 Zoinks!
 Zola Jesus

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -45,16 +45,6 @@ class AudioFileManager(object):
         for row in rows:
             w.writerow(row)
 
-    def get_audiofiles(self, fingerprints):
-        audio_files = []
-        for fingerprint in fingerprints:
-            af = self.db.get_by_fingerprint(fingerprint)
-            if not af:
-                raise Exception(
-                    'Fingerprint %s has no record in the db.' % fingerprint)
-            audio_files.append(af)
-        return audio_files
-
     def get_rows(self, fingerprints, table):
         sql = ("SELECT * "
                "FROM %s "

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -116,29 +116,26 @@ def main():
     sys.stdout.write("Using database: {}\n".format(afm.db_path))
 
     fingerprints = args.fingerprint
-    try:
-        tags = afm.get_tags(fingerprints)
 
-        audio_files = list(afm.get_audio_files(fingerprints))
-        sys.stdout.write("\nROWS TO DELETE from audio_files\n\n")
-        afm.print_rows(audio_files)
+    tags = afm.get_tags(fingerprints)
 
-        sys.stdout.write("\nROWS TO DELETE from id3_tags\n\n")
-        afm.print_rows(tags)
+    audio_files = list(afm.get_audio_files(fingerprints))
+    sys.stdout.write("\nROWS TO DELETE from audio_files\n\n")
+    afm.print_rows(audio_files)
 
-        if set(fingerprints) != set(f["fingerprint"] for f in audio_files):
-            sys.stdout.write(
-                "\n\nWARNING: A fingerprint was given that does not match "
-                "an audio file in the database\n\n")
+    sys.stdout.write("\nROWS TO DELETE from id3_tags\n\n")
+    afm.print_rows(tags)
 
-        if args.delete:
-            afm.del_audiofiles(fingerprints)
-            sys.stdout.write("\nDELETED\n")
-        else:
-            sys.stdout.write("\nNOTHING DELETED.  Pass in the --delete flag.\n")
-    except Exception as e:
-        raise
-        sys.stderr.write("ERROR: {}\n".format(str(e)))
+    if set(fingerprints) != set(f["fingerprint"] for f in audio_files):
+        sys.stdout.write(
+            "\n\nWARNING: A fingerprint was given that does not match "
+            "an audio file in the database\n\n")
+
+    if args.delete:
+        afm.del_audiofiles(fingerprints)
+        sys.stdout.write("\nDELETED\n")
+    else:
+        sys.stdout.write("\nNOTHING DELETED.  Pass in the --delete flag.\n")
 
 
 if __name__ == "__main__":

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -4,14 +4,14 @@ Remove audio files and their M3U tags based on a fingerprints id given
 Usage:
 
     See what will be deleted:
-    ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id>
+    do_delete_audio_file_from_db <fingerprint_id> <fingerprint_id>
 
     Actually delete:
-    ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id> --delete
+    do_delete_audio_file_from_db <fingerprint_id> <fingerprint_id> --delete
 
 Flags:
- --db = specify a filesystem path to an alternate location for the sqlite database file 
- --delete = actually do the delete. Nothing will be deleted without this flag. 
+ --db = specify a filesystem path to an alternate location for the sqlite database file
+ --delete = actually do the delete. Nothing will be deleted without this flag.
 
 """
 

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -64,23 +64,19 @@ class AudioFileManager(object):
                "FROM %s "
                "WHERE fingerprint IN (%s) "
                ) % (table, ",".join("?" * len(fingerprints)))
-        try:
-            self.conn.execute(sql, fingerprints)
-        except:
-            self.conn.rollback()
-            raise
+
+        self.conn.execute(sql, fingerprints)
 
     def del_tags(self, fingerprints):
         self.del_rows(fingerprints, table="id3_tags")
 
     def del_audiofiles(self, fingerprints):
-
         try:
             self.del_tags(fingerprints)
-        except:
-            raise
-        else:
             self.del_rows(fingerprints, table="audio_files")
+        except:
+            self.conn.rollback()
+        else:
             self.conn.commit()
 
 

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -74,8 +74,11 @@ class AudioFileManager(object):
                "FROM %s "
                "WHERE fingerprint IN (%s) "
                ) % (table, ",".join("?" * len(fingerprints)))
-        self.conn.execute(sql, fingerprints)
-        self.conn.commit()
+        try:
+            self.conn.execute(sql, fingerprints)
+        except:
+            self.conn.rollback()
+            raise
 
     def del_tags(self, fingerprints):
         self.del_rows(fingerprints, table="id3_tags")
@@ -88,6 +91,7 @@ class AudioFileManager(object):
             raise
         else:
             self.del_rows(fingerprints, table="audio_files")
+            self.conn.commit()
 
 
 def main():

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -10,7 +10,8 @@ Usage:
     do_delete_audio_file_from_db <fingerprint_id> <fingerprint_id> --delete
 
 Flags:
- --db = specify a filesystem path to an alternate location for the sqlite database file
+ --db = specify a filesystem path to an alternate location for the sqlite
+        database file
  --delete = actually do the delete. Nothing will be deleted without this flag.
 
 """
@@ -74,8 +75,9 @@ class AudioFileManager(object):
         try:
             self.del_tags(fingerprints)
             self.del_rows(fingerprints, table="audio_files")
-        except:
+        except Exception:
             self.conn.rollback()
+            raise
         else:
             self.conn.commit()
 

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""
+Remvoe audio files and their M3U tags based on a fingerprints id given
+Usage:
+
+    See what will be deleted:
+    ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id>
+
+    Actually delete:
+    ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id> --delete
+
+"""
+
+import sys
+import csv
+import sqlite3
+import argparse
+from chirp.common.conf import LIBRARY_DB
+from chirp.library import database
+
+
+class AudioFileManager(object):
+
+    def __init__(self, library_db_file=None):
+        if not library_db_file:
+            library_db_file = LIBRARY_DB
+        self.db = database.Database(LIBRARY_DB)
+        self.conn = self.db._get_connection()
+        self.conn.row_factory = sqlite3.Row
+
+    def _select_rows(self, cursor):
+        while True:
+            item = cursor.fetchone()
+            if item is None:
+                break
+            yield item
+
+    def print_rows(self, rows):
+        w = csv.writer(sys.stdout, delimiter=',')
+        for row in rows:
+            w.writerow(row)
+
+    def get_audiofiles(self, fingerprints):
+        audio_files = []
+        for fingerprint in fingerprints:
+            af = self.db.get_by_fingerprint(fingerprint)
+            if not af:
+                raise Exception('Fingerprint %s has no record in the db.' % fingerprint)
+            audio_files.append(af)
+        return audio_files
+
+    def get_rows(self, fingerprints, table):
+        sql = ("SELECT * "
+               "FROM %s "
+               "WHERE fingerprint IN (%s) "
+               ) % (table, ",".join("?" * len(fingerprints)))
+        cursor = self.conn.execute(sql, fingerprints)
+        return self._select_rows(cursor)
+
+    def get_tags(self, fingerprints):
+        return self.get_rows(fingerprints, table="id3_tags")
+
+    def get_audio_files(self, fingerprints):
+        return self.get_rows(fingerprints, table="audio_files")
+
+    def del_rows(self, fingerprints, table):
+        sql = ("DELETE "
+               "FROM %s "
+               "WHERE fingerprint IN (%s) "
+               ) % (table, ",".join("?" * len(fingerprints)))
+        self.conn.execute(sql, fingerprints)
+        self.conn.commit()
+
+    def del_tags(self, fingerprints):
+        self.del_rows(fingerprints, table="id3_tags")
+
+    def del_audiofiles(self, fingerprints):
+
+        try:
+            self.del_tags(fingerprints)
+        except:
+            raise
+        else:
+            self.del_rows(fingerprints, table="audio_files")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Manage records in audio file sqlite database.')
+    parser.add_argument(
+        'fingerprint', type=str, nargs='+',
+        help='an integer for the accumulator')
+    parser.add_argument(
+        '--delete', action="store_true",
+        help='Delete the audiofile based on the fingerprint passed in')
+    args = parser.parse_args()
+
+    afm = AudioFileManager()
+
+    sys.stdout.write("ARGS: {} \n\n".format(str(args)))
+    fingerprints = args.fingerprint
+    try:
+        tags = afm.get_tags(fingerprints)
+
+        audio_files = list(afm.get_audio_files(fingerprints))
+        sys.stdout.write("\nROWS TO DELETE from audio_files\n\n")
+        afm.print_rows(audio_files)
+
+        sys.stdout.write("\nROWS TO DELETE from id3_tags\n\n")
+        afm.print_rows(tags)
+
+        if set(fingerprints) != set(f["fingerprint"] for f in audio_files):
+            sys.stdout.write(
+                "\n\nWARNING: A fingerprint was given that does not match "
+                "an audio file in the database\n\n")
+
+        if args.delete:
+            afm.del_audiofiles(fingerprints)
+            sys.stdout.write("\nDELETED\n")
+        else:
+            sys.stdout.write("\nNOTHING DELETED.  Pass in the --delete flag.\n")
+    except Exception as e:
+        raise
+        sys.stderr.write("ERROR: {}\n".format(str(e)))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -52,7 +52,7 @@ class DeleteFingerprintTest(unittest.TestCase):
             library_db_file=self.name)
 
         # TEST
-        afm.del_audiofiles([test_fingerprint, ])
+        afm.del_audiofiles([test_fingerprint])
 
         # RESUTLS
         # verify audiofile doesn't exist
@@ -112,7 +112,7 @@ class DeleteFingerprintTest(unittest.TestCase):
             library_db_file=self.name)
 
         # TEST
-        afm.del_audiofiles([test_fingerprint_1, ])
+        afm.del_audiofiles([test_fingerprint_1])
 
         # RESUTLS
         # make sure nothing was deleted

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -16,6 +16,9 @@ class DeleteFingerprintTest(unittest.TestCase):
         self.name = TEST_DB_NAME_PATTERN % int(time.time() * 1000000)
         self.db = database.Database(self.name)
 
+    def tearDown(self):
+        os.unlink(self.name)
+
     def _add_test_audiofiles(self):
         test_volume = 17
         test_import_timestamp = 1230959520
@@ -192,6 +195,3 @@ class DeleteFingerprintTest(unittest.TestCase):
 
         # RESULTS
         self.assertEqual(len(list(af)), 0)
-
-    def tearDown(self):
-        os.unlink(self.name)

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -1,3 +1,4 @@
+import os
 import time
 import unittest
 
@@ -225,3 +226,6 @@ class DeleteFingerprintTest(unittest.TestCase):
 
         # RESUTLS
         self.assertEqual(len(list(af)), 0)
+
+    def tearDown(self):
+        os.unlink(self.name)

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -132,27 +132,10 @@ class DeleteFingerprintTest(unittest.TestCase):
         # TEST
         af = afm.get_audio_files(fingerprints=[test_fingerprint])
 
-        # RESUTLS
-        self.assertEqual(len(list(af)), 1)
-
-    def test_get_audio_files__existing_records(self):
-        # SETUP
-        test_fingerprint_1 = "0000000000000005"
-        test_fingerprint_2 = "0000000000000007"
-
-        # Create db tables
-        self.assertTrue(self.db.create_tables())
-        self._add_test_audiofiles()
-
-        afm = do_delete_audio_file_from_db.AudioFileManager(
-                    library_db_file=self.name)
-
-        # TEST
-        af = afm.get_audio_files(
-            fingerprints=[test_fingerprint_1, test_fingerprint_2])
-
-        # RESUTLS
-        self.assertEqual(len(list(af)), 2)
+        # RESULTS
+        self.assertSetEqual(
+            set(a['fingerprint'] for a in af),
+            set([test_fingerprint]))
 
     def test_get_audio_files__non_existing_records(self):
         # SETUP
@@ -187,27 +170,10 @@ class DeleteFingerprintTest(unittest.TestCase):
         af = afm.get_tags(
             fingerprints=[test_fingerprint_1])
 
-        # RESUTLS
-        self.assertEqual(len(list(af)), 5)
-
-    def test_get_tags__existing_records(self):
-        # SETUP
-        test_fingerprint_1 = "0000000000000005"
-        test_fingerprint_2 = "0000000000000007"
-
-        # Create db tables
-        self.assertTrue(self.db.create_tables())
-        self._add_test_audiofiles()
-
-        afm = do_delete_audio_file_from_db.AudioFileManager(
-                    library_db_file=self.name)
-
-        # TEST
-        af = afm.get_tags(
-            fingerprints=[test_fingerprint_1, test_fingerprint_2])
-
-        # RESUTLS
-        self.assertEqual(len(list(af)), 10)
+        # RESULTS
+        self.assertListEqual(
+            list(a['fingerprint'] for a in af),
+            5 * [test_fingerprint_1])
 
     def test_get_tags__non_existing_records(self):
         # SETUP

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -146,12 +146,6 @@ class DeleteFingerprintTest(unittest.TestCase):
                 afm.del_audiofiles([test_fingerprint_1])
             mock_conn.rollback.assert_called_with()
 
-        # RESULTS
-        # make sure nothing was deleted
-        self.assertEqual(len(list(self.db.get_all())), 10)
-        # make sure tags are sitll there for the fingerprint we tried to delete
-        self.assertEqual(len(list(afm.get_tags([test_fingerprint_1]))), 5)
-
     def test_get_audio_files__existing_record(self):
         # SETUP
         test_fingerprint = "0000000000000007"

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -1,0 +1,227 @@
+import time
+import unittest
+
+from chirp.library import audio_file_test
+from chirp.library import do_delete_audio_file_from_db
+from chirp.library import database
+
+
+TEST_DB_NAME_PATTERN = "/tmp/chirp-library-db_test.%d.sqlite"
+
+
+class DeleteFingerprintTest(unittest.TestCase):
+
+    def setUp(self):
+        self.name = TEST_DB_NAME_PATTERN % int(time.time() * 1000000)
+        self.db = database.Database(self.name)
+
+    def _add_test_audiofiles(self):
+        test_volume = 17
+        test_import_timestamp = 1230959520
+
+        # populate some dummy audiofiles into the database
+        all_au_files = [audio_file_test.get_test_audio_file(i)
+                        for i in xrange(10)]
+        add_txn = self.db.begin_add(test_volume, test_import_timestamp)
+
+        for au_file in all_au_files:
+            au_file.volume = test_volume
+            au_file.import_timestamp = test_import_timestamp
+
+        for au_file in all_au_files:
+            add_txn.add(au_file)
+        add_txn.commit()
+
+    def test_del_audiofilese__full_delete_single(self):
+        # SETUP
+        test_fingerprint = "0000000000000007"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        # make sure 10 records exist
+        self.assertEqual(len(list(self.db.get_all())), 10)
+
+        # quick confirmation that the audiofile that we want to test exists.
+        af = self.db.get_by_fingerprint(test_fingerprint)
+        self.assertEquals(af.fingerprint, test_fingerprint)
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+            library_db_file=self.name)
+
+        # TEST
+        afm.del_audiofiles([test_fingerprint, ])
+
+        # RESUTLS
+        # verify audiofile doesn't exist
+        af = self.db.get_by_fingerprint(test_fingerprint)
+        self.assertEquals(af, None)
+
+        # make sure only 9 records exist now
+        self.assertEqual(len(list(self.db.get_all())), 9)
+
+    def test_del_audiofiles__full_delete_multiple(self):
+        # SETUP
+        test_fingerprint_1 = "0000000000000005"
+        test_fingerprint_2 = "0000000000000007"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        # make sure 10 records exist
+        self.assertEqual(len(list(self.db.get_all())), 10)
+
+        # quick confirmation that the audiofiles that we want to test exists.
+        af = self.db.get_by_fingerprint(test_fingerprint_1)
+        self.assertEquals(af.fingerprint, test_fingerprint_1)
+        af = self.db.get_by_fingerprint(test_fingerprint_2)
+        self.assertEquals(af.fingerprint, test_fingerprint_2)
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+            library_db_file=self.name)
+
+        # TEST
+        afm.del_audiofiles([test_fingerprint_1, test_fingerprint_2])
+
+        # RESUTLS
+        # verify audiofiles don't exist
+        af = self.db.get_by_fingerprint(test_fingerprint_1)
+        self.assertEquals(af, None)
+
+        af = self.db.get_by_fingerprint(test_fingerprint_2)
+        self.assertEquals(af, None)
+
+        # make sure only 8 records exist now
+        self.assertEqual(len(list(self.db.get_all())), 8)
+
+    def test_del_audiofiles__full_delete_non_existing_fingerprint(self):
+        # SETUP
+        test_fingerprint_1 = "0000000000000020"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        # make sure 10 records exist
+        self.assertEqual(len(list(self.db.get_all())), 10)
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+            library_db_file=self.name)
+
+        # TEST
+        afm.del_audiofiles([test_fingerprint_1, ])
+
+        # RESUTLS
+        # make sure nothing was deleted
+        self.assertEqual(len(list(self.db.get_all())), 10)
+
+    def test_get_audio_files__existing_record(self):
+        # SETUP
+        test_fingerprint = "0000000000000007"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+                    library_db_file=self.name)
+
+        # TEST
+        af = afm.get_audio_files(fingerprints=[test_fingerprint])
+
+        # RESUTLS
+        self.assertEqual(len(list(af)), 1)
+
+    def test_get_audio_files__existing_records(self):
+        # SETUP
+        test_fingerprint_1 = "0000000000000005"
+        test_fingerprint_2 = "0000000000000007"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+                    library_db_file=self.name)
+
+        # TEST
+        af = afm.get_audio_files(
+            fingerprints=[test_fingerprint_1, test_fingerprint_2])
+
+        # RESUTLS
+        self.assertEqual(len(list(af)), 2)
+
+    def test_get_audio_files__non_existing_records(self):
+        # SETUP
+        test_fingerprint_1 = "0000000000000020"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+                    library_db_file=self.name)
+
+        # TEST
+        af = afm.get_audio_files(
+            fingerprints=[test_fingerprint_1])
+
+        # RESUTLS
+        self.assertEqual(len(list(af)), 0)
+
+    def test_get_tags__existing_record(self):
+        # SETUP
+        test_fingerprint_1 = "0000000000000005"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+                    library_db_file=self.name)
+
+        # TEST
+        af = afm.get_tags(
+            fingerprints=[test_fingerprint_1])
+
+        # RESUTLS
+        self.assertEqual(len(list(af)), 5)
+
+    def test_get_tags__existing_records(self):
+        # SETUP
+        test_fingerprint_1 = "0000000000000005"
+        test_fingerprint_2 = "0000000000000007"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+                    library_db_file=self.name)
+
+        # TEST
+        af = afm.get_tags(
+            fingerprints=[test_fingerprint_1, test_fingerprint_2])
+
+        # RESUTLS
+        self.assertEqual(len(list(af)), 10)
+
+    def test_get_tags__non_existing_records(self):
+        # SETUP
+        test_fingerprint_1 = "0000000000000020"
+
+        # Create db tables
+        self.assertTrue(self.db.create_tables())
+        self._add_test_audiofiles()
+
+        afm = do_delete_audio_file_from_db.AudioFileManager(
+                    library_db_file=self.name)
+
+        # TEST
+        af = afm.get_tags(
+            fingerprints=[test_fingerprint_1])
+
+        # RESUTLS
+        self.assertEqual(len(list(af)), 0)

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -54,7 +54,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         # TEST
         afm.del_audiofiles([test_fingerprint])
 
-        # RESUTLS
+        # RESULTS
         # verify audiofile doesn't exist
         af = self.db.get_by_fingerprint(test_fingerprint)
         self.assertEquals(af, None)
@@ -86,7 +86,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         # TEST
         afm.del_audiofiles([test_fingerprint_1, test_fingerprint_2])
 
-        # RESUTLS
+        # RESULTS
         # verify audiofiles don't exist
         af = self.db.get_by_fingerprint(test_fingerprint_1)
         self.assertEquals(af, None)
@@ -114,7 +114,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         # TEST
         afm.del_audiofiles([test_fingerprint_1])
 
-        # RESUTLS
+        # RESULTS
         # make sure nothing was deleted
         self.assertEqual(len(list(self.db.get_all())), 10)
 
@@ -152,7 +152,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         af = afm.get_audio_files(
             fingerprints=[test_fingerprint_1])
 
-        # RESUTLS
+        # RESULTS
         self.assertEqual(len(list(af)), 0)
 
     def test_get_tags__existing_record(self):
@@ -190,7 +190,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         af = afm.get_tags(
             fingerprints=[test_fingerprint_1])
 
-        # RESUTLS
+        # RESULTS
         self.assertEqual(len(list(af)), 0)
 
     def tearDown(self):

--- a/chirp/library/do_delete_audio_file_from_db_test.py
+++ b/chirp/library/do_delete_audio_file_from_db_test.py
@@ -127,7 +127,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         self._add_test_audiofiles()
 
         afm = do_delete_audio_file_from_db.AudioFileManager(
-                    library_db_file=self.name)
+            library_db_file=self.name)
 
         # TEST
         af = afm.get_audio_files(fingerprints=[test_fingerprint])
@@ -146,7 +146,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         self._add_test_audiofiles()
 
         afm = do_delete_audio_file_from_db.AudioFileManager(
-                    library_db_file=self.name)
+            library_db_file=self.name)
 
         # TEST
         af = afm.get_audio_files(
@@ -164,7 +164,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         self._add_test_audiofiles()
 
         afm = do_delete_audio_file_from_db.AudioFileManager(
-                    library_db_file=self.name)
+            library_db_file=self.name)
 
         # TEST
         af = afm.get_tags(
@@ -184,7 +184,7 @@ class DeleteFingerprintTest(unittest.TestCase):
         self._add_test_audiofiles()
 
         afm = do_delete_audio_file_from_db.AudioFileManager(
-                    library_db_file=self.name)
+            library_db_file=self.name)
 
         # TEST
         af = afm.get_tags(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Nose
 mutagen==1.16
+mock>=2.0.0
 simplejson
 PyCrypto

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ setup(
        remove_from_dropbox = chirp.library.remove_from_dropbox:main
        empty_dropbox = chirp.library.empty_dropbox:main
 
+       do_delete_audio_file_from_db = chirp.library.do_delete_audio_file_from_db:main
        do_archive_stream = chirp.stream.do_archive_stream:main
        do_proxy_barix_status = chirp.stream.do_proxy_barix_status:main
        """,
-    classifiers = [],
+    classifiers=[],
     )


### PR DESCRIPTION
This is to implement a script to allow removal of individual records of an audio file in the audio file sqlite3 database, given the fingerprint id. It will remove records from two tables in the database: id3_tags and audio_files.  This does not delete the actual audio file from the filesystem (just the reference to it in the db). 

This PR does not modify any existing code, but uses a few imports from the existing codebase. 

TEST
Refer to the usage steps below. Select an audiofile fingerprint from the sqlite database. Optionally use  the --db flag to pass in an alternate path to a database file. 

DEPLOY
No special steps are needed for deployment (other than code checkout)

```
Remove audio files and their M3U tags based on a fingerprints id given
Usage:

    See what will be deleted:
    ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id>

    Actually delete:
    ./do_delete_auto_file_from_db.py <fingerprint_id> <fingerprint_id> --delete

Flags:
 --db = specify a filesystem path to an alternate location for the sqlite database file 
 --delete = actually do the delete. Nothing will be deleted without this flag. 

```