### PR TITLE
Fix issue with file deletion script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,16 @@ Installation
 ------------------
 
 You'll need Python 2.7+, `Google App Engine SDK 1.9+`_, `virtualenv`_ and `pip`_.
-Change into the source tree, activate a virtualenv, and type these commands::
+Change into the source tree, activate a virtualenv, and type this to install all development requirements::
 
-  pip install -r requirements.txt
+  pip install -r requirements/dev.txt
+
+For only the production requirements, type this::
+
+  pip install -r requirements/prod.txt
+
+Next, install the module as a symlink, install the scripts, and generate a local settings file::
+
   python setup.py develop
   cp settings_local.py-dist settings_local.py
 

--- a/chirp/library/do_delete_audio_file_from_db.py
+++ b/chirp/library/do_delete_audio_file_from_db.py
@@ -44,7 +44,9 @@ class AudioFileManager(object):
     def print_rows(self, rows):
         w = csv.writer(sys.stdout, delimiter=',')
         for row in rows:
-            w.writerow(row)
+            # An older version of the csv module requires the writerow()
+            # argument to be a list type.
+            w.writerow(list(row))
 
     def get_rows(self, fingerprints, table):
         sql = ("SELECT * "

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,3 @@
+-r prod.txt
+Nose
+mock>=2.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,4 @@
-Nose
 mutagen==1.16
-mock>=2.0.0
 simplejson
 # This is used by the do_push_artists_to_chirpradio command (maybe?)
 # when it loads the App Engine SDK.


### PR DESCRIPTION
This fixes a traceback that was only happening in Python 2.7.2

```
Traceback (most recent call last):

  File "/home/musiclib/.virtualenvs/chirpradio-machine/bin/do_delete_audio_file_from_db", line 9, in <module>

    load_entry_point('chirp==2.0', 'console_scripts', 'do_delete_audio_file_from_db')()

  File "/home/musiclib/chirpradio-machine/chirp/library/do_delete_audio_file_from_db.py", line 116, in main

    afm.print_rows(audio_files)

  File "/home/musiclib/chirpradio-machine/chirp/library/do_delete_audio_file_from_db.py", line 47, in print_rows

    w.writerow(row)

_csv.Error: sequence expected
```